### PR TITLE
Fix Jekyll theme configuration and asset loading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -34,5 +34,6 @@ exclude:
   - temp_outdated.json
   - test_outdated.json
   - outdated_packages.json
+  - test_jekyll_build.sh
   - "*.pyc"
   - __pycache__

--- a/test_jekyll_build.sh
+++ b/test_jekyll_build.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Test script to verify Jekyll build works correctly before deployment
+
+set -e
+
+echo "Testing Jekyll build..."
+
+# Ensure we have the C++ compiler in PATH for eventmachine gem
+export PATH="$HOME/.local/bin:$PATH"
+
+# Install dependencies
+echo "Installing bundle dependencies..."
+bundle install --quiet
+
+# Build the site
+echo "Building Jekyll site..."
+bundle exec jekyll build
+
+# Verify critical assets exist
+echo "Verifying assets..."
+test -f _site/index.html || { echo "ERROR: index.html not found"; exit 1; }
+test -f _site/public/css/poole.css || { echo "ERROR: poole.css not found"; exit 1; }
+test -f _site/public/css/lanyon.css || { echo "ERROR: lanyon.css not found"; exit 1; }
+test -f _site/public/css/syntax.css || { echo "ERROR: syntax.css not found"; exit 1; }
+test -f _site/public/js/script.js || { echo "ERROR: script.js not found"; exit 1; }
+
+# Verify no doubled baseurl in paths
+echo "Checking for path issues..."
+if grep -q "/flatpak-tracker/flatpak-tracker/" _site/index.html; then
+    echo "ERROR: Found doubled baseurl path in index.html"
+    exit 1
+fi
+
+# Verify correct single baseurl path (should contain /flatpak-tracker/public but not doubled)
+if ! grep -q '/flatpak-tracker/public/css/' _site/index.html; then
+    echo "ERROR: CSS paths don't contain correct baseurl in index.html"
+    exit 1
+fi
+
+echo "✅ All tests passed! Jekyll site builds correctly."


### PR DESCRIPTION
## Summary

This PR fixes the Jekyll theme configuration issues that were preventing the site from rendering correctly.

## Issues Fixed

1. **Empty plugins array** - Jekyll 4.x requires plugins to be an array, not nil, which was causing build failures
2. **Doubled baseurl path** - The URL configuration included  causing asset paths like  (404 errors)
3. **Missing build verification** - Added test script to ensure Jekyll builds correctly before deployment

## Changes

### Commit 1: Fix Jekyll configuration: add plugins array
- Added required plugins to `_config.yml`: `jekyll-paginate`, `jekyll-gist`, `jekyll-seo-tag`
- Resolves "plugins should be set as an array" error

### Commit 2: Fix Jekyll baseurl to prevent doubled path in asset URLs
- Changed `url` from `https://ublue-os.github.io/flatpak-tracker` to `https://ublue-os.github.io`
- Kept `baseurl` as `/flatpak-tracker`
- CSS now loads from correct path: `/flatpak-tracker/public/css/` instead of `/flatpak-tracker/flatpak-tracker/public/css/`

### Commit 3: Add Jekyll build test script
- Created `test_jekyll_build.sh` to verify builds work locally
- Tests: asset presence, path correctness, no doubled baseurls
- Added script to exclude list in `_config.yml`

## Testing

✅ Local build verified: `bundle exec jekyll build`
✅ Local serve verified: `bundle exec jekyll serve`
✅ All assets present in `_site/public/`
✅ CSS paths correct in generated HTML
✅ Test script passes all checks
✅ No doubled baseurl paths found

## Result

When merged, the GitHub Pages site at https://ublue-os.github.io/flatpak-tracker/ will display correctly with proper CSS styling and the Lanyon theme will render as intended.