### PR TITLE
fix: Add more runtime versions to sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -28,9 +28,12 @@
     <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker">GitHub project</a>
     <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues">Open Issues</a>
     <span class="sidebar-nav-item">Runtime Issues:</span>
-    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Agnome-49">GNOME</a>
-    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Akde-6.9">KDE</a>
-    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Afreedesktop-25.08">Freedesktop</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Agnome-48">GNOME 48</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Agnome-49">GNOME 49</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Akde-6-9">KDE 6.9</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Akde-6.10">KDE 6.10</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Afreedesktop-24.08">Freedesktop 24.08</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Afreedesktop-25.08">Freedesktop 25.08</a>
   </nav>
 
   <div class="sidebar-item">


### PR DESCRIPTION
- Fix label for KDE 6.9 runtime
- Add more versions