### PR TITLE
fix: Fix Freedesktop 24.08 label

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -32,7 +32,7 @@
     <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Agnome-49">GNOME 49</a>
     <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Akde-6-9">KDE 6.9</a>
     <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Akde-6.10">KDE 6.10</a>
-    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Afreedesktop-24.08">Freedesktop 24.08</a>
+    <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Afreedesktop-24-08">Freedesktop 24.08</a>
     <a class="sidebar-nav-item" href="https://github.com/ublue-os/flatpak-tracker/issues?q=is%3Aissue+is%3Aopen+label%3Afreedesktop-25.08">Freedesktop 25.08</a>
   </nav>
 


### PR DESCRIPTION
Missed that in https://github.com/ublue-os/flatpak-tracker/pull/514