### PR TITLE
Fix non-scrollable tables on small screens

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="{{ '/public/css/poole.css' | absolute_url }}">
   <link rel="stylesheet" href="{{ '/public/css/syntax.css' | absolute_url }}">
   <link rel="stylesheet" href="{{ '/public/css/lanyon.css' | absolute_url }}">
+  <link rel="stylesheet" href="{{ '/public/css/custom.css' | absolute_url }}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Serif:400,400italic,700%7CPT+Sans:400">
 
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ '/public/apple-touch-icon-precomposed.png' | absolute_url }}">

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -1,0 +1,7 @@
+table {
+    /* Allow table to overflow and users to scroll on small screens */
+    @media (max-width: 1280px) {
+        overflow-x: auto;
+        display: block;
+    }
+}


### PR DESCRIPTION
Hello,

Because of the layout used, tables overflow and right-most rows cannot be read on small screens. The solution provided in this PR fixes this but isn't ideal: it would be best to modify the existing layout, but I elected not to without consulting you first.

Regards,
Axel